### PR TITLE
feat: support covergae per spec

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -67,6 +67,8 @@ var CoverageReporter = function(rootConfig, emitter, helper, logger) {
     var collector = collectors[browser.id];
     if (cov && collector) {
       collector.add(cov);
+    }
+    if (collector) {
       pendingFileWritings++;
       helper.mkdirIfNotExists(path.resolve(outDir), function() {
         var now = dateformat(new Date(), 'yyyymmdd_HHMMss');
@@ -78,6 +80,12 @@ var CoverageReporter = function(rootConfig, emitter, helper, logger) {
           writeEnd();
         });
       });
+    }
+  };
+
+  this.onSpecComplete = function(browser, result) {
+    if (result.coverage) {
+      collectors[browser.id].add(result.coverage);
     }
   };
 


### PR DESCRIPTION
For e2e tests, the coverage is reported after each spec end, so the coverage reporter needs to handle this.
