### PR TITLE
feat: Allow multiple report types to be used

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -54,6 +54,10 @@ var CoverageReporter = function(rootConfig, emitter, helper, logger) {
 
   function writeEnd() {
     if (!--pendingFileWritings) {
+      // cleanup collectors
+      Object.keys(collectors).forEach(function(key) {
+         collectors[key].dispose();
+      });
       fileWritingFinished();
     }
   }
@@ -112,7 +116,6 @@ var CoverageReporter = function(rootConfig, emitter, helper, logger) {
             } catch (e) {
               log.error(e);
             }
-            collector.dispose();
             writeEnd();
           });
         }


### PR DESCRIPTION
I wanted a way to run multiple reports at the same time.  Specifically I wanted to see a text summary in the console but still have a way to get to the full html report to see line level details. 

This change refactors the way the coverageReporter configuration works by adding a new 'reporters' property.  This property is a list of configurations for any reporters that should be used.  This allows the user to ask for multiple output types at the same time.

For example:

``` javascript
coverageReporter: {
    dir : 'coverage/',
    reporters: [{
      type: 'html'
    }, {
      type: 'text'
    }, {
      type: 'cobertura'
    }]
}
```

This configuration outputs reports in html, text, and cobertura from the same run of karma.

Note: the code is designed to be backwards compatible with the older method of specifying the options.
