### PR TITLE
Support CoffeeScript code coverage 

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,42 @@ module.exports = function(config) {
 };
 ```
 
+example use with CoffeeScript project...
+```js
+// karma.conf.js
+module.exports = function(config) {
+  config.set({
+    files: [
+      'src/**/*.coffee',
+      'test/**/*.coffee'
+    ],
+
+    // coverage reporter generates the coverage
+    reporters: ['progress', 'coverage'],
+
+    preprocessors: {
+      // source files, that you wanna generate coverage for
+      // do not include tests or libraries
+      // (these files will be instrumented by Istanbul via Ibrik)
+      'src/*.coffee': ['coverage'],
+
+      // note: project files will already be converted to
+      // JavaScript via coverage preprocessor.
+      // Thus, you'll have to limit the CoffeeScript preprocessor
+      // to uncovered files.
+      'test/**/*.coffee': ['coffee']
+    },
+
+    // optionally, configure the reporter
+    coverageReporter: {
+      type : 'html',
+      dir : 'coverage/'
+    }
+  });
+};
+
+```
+
 ### Options
 #### type
 **Type:** String

--- a/package.json
+++ b/package.json
@@ -15,12 +15,16 @@
     "karma-preprocessor",
     "karma-reporter",
     "coverage",
-    "istanbul"
+    "istanbul",
+    "ibrik"
   ],
   "author": "SATO taichi <ryushi@gmail.com>",
+  "contributors": [
+    "Kyle Welsby <kyle@mekyle.com> (http://mekyle.com)"
+  ],
   "dependencies": {
     "istanbul": "~0.1.45",
-    "ibrik":  "~1.0.1",
+    "ibrik":  "git+https://github.com/HBOCodeLabs/ibrik.git#304cd84936d33cf38a05a1a4fe58c82d54ff6cfa",
     "dateformat": "~1.0.6"
   },
   "peerDependencies": {


### PR DESCRIPTION
Building on top of the work the @can3p has committed.  I found that the [CoffeeScript-redux](https://github.com/michaelficarra/CoffeeScriptRedux) compiler was too strict.  @jstamerj done an amazing job of switching [CoffeeScript-redux](https://github.com/michaelficarra/CoffeeScriptRedux) to standard [CoffeeScript](https://github.com/jashkenas/coffee-script) in [Ibrik](https://github.com/jstamerj/ibrik/tree/9d9db260e6f1e558d052996c198e742378311fc6).

I just glued the bits together and updated the README to help avid CoffeeScript users add Coverage support to their projects.

This should resolve #12 and karma-runner/karma#622

Enjoy
