### PR TITLE
Fix issue #22 (support HTML detail report for compiled CoffeeScript, etc)

### DIFF
--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -1,8 +1,10 @@
 var istanbul = require('istanbul');
+var globalSourceCache = require('./sourceCache');
 
 var createCoveragePreprocessor = function(logger, basePath, reporters) {
   var log = logger.create('preprocessor.coverage');
   var instrumenter = new istanbul.Instrumenter();
+  var sourceCache = globalSourceCache.getByBasePath(basePath);
 
   // if coverage reporter is not used, do not preprocess the files
   if (reporters.indexOf('coverage') === -1) {
@@ -19,6 +21,10 @@ var createCoveragePreprocessor = function(logger, basePath, reporters) {
       if(err) {
         log.error('%s\n  at %s', err.message, file.originalPath);
       }
+
+      // remember the actual immediate instrumented JS for given original path
+      sourceCache[jsPath] = content;
+
       done(instrumentedCode);
     });
   };

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -3,35 +3,31 @@ var fs = require('fs');
 var util = require('util');
 var istanbul = require('istanbul');
 var dateformat = require('dateformat');
+var globalSourceCache = require('./sourceCache');
 
 
 var Store = istanbul.Store;
 
-var BasePathStore = function(opts) {
+var SourceCacheStore = function(opts) {
   Store.call(this, opts);
   opts = opts || {};
-  this.basePath = opts.basePath;
-  this.delegate = Store.create('fslookup');
+  this.sourceCache = opts.sourceCache;
 };
-BasePathStore.TYPE = 'basePathlookup';
-util.inherits(BasePathStore, Store);
+SourceCacheStore.TYPE = 'sourceCacheLookup';
+util.inherits(SourceCacheStore, Store);
 
-Store.mix(BasePathStore, {
+Store.mix(SourceCacheStore, {
   keys : function() {
-    return this.delegate.keys();
-  },
-  toKey : function(key) {
-    if (key.indexOf('./') === 0) { return path.join(this.basePath, key); }
-    return key;
+    throw 'not implemented';
   },
   get : function(key) {
-    return this.delegate.get(this.toKey(key));
+    return this.sourceCache[key];
   },
   hasKey : function(key) {
-    return this.delegate.hasKey(this.toKey(key));
+    return this.sourceCache.hasOwnProperty(key);
   },
   set : function(key, contents) {
-    return this.delegate.set(this.toKey(key), contents);
+    throw 'not applicable';
   }
 });
 
@@ -43,6 +39,7 @@ var CoverageReporter = function(rootConfig, emitter, helper, logger) {
   var basePath = rootConfig.basePath;
   var outDir = config.dir;
   var reporters = config.reporters;
+  var sourceCache = globalSourceCache.getByBasePath(basePath);
 
   if (!helper.isDefined(reporters)) {
     reporters = [config];
@@ -110,8 +107,8 @@ var CoverageReporter = function(rootConfig, emitter, helper, logger) {
           helper.mkdirIfNotExists(out, function() {
             var options = helper.merge({}, reporterConfig, {
               dir : out,
-              sourceStore : new BasePathStore({
-                basePath : basePath
+              sourceStore : new SourceCacheStore({
+                sourceCache: sourceCache
               })
             });
             var reporter = istanbul.Report.create(reporterConfig.type, options);

--- a/lib/sourceCache.js
+++ b/lib/sourceCache.js
@@ -1,0 +1,6 @@
+
+var cacheByBasePath = {};
+
+exports.getByBasePath = function (basePath) {
+    return cacheByBasePath[basePath] ? cacheByBasePath[basePath] : (cacheByBasePath[basePath] = {});
+};

--- a/test/reporter.spec.coffee
+++ b/test/reporter.spec.coffee
@@ -23,12 +23,6 @@ describe 'reporter', ->
   mockStore = sinon.spy()
   mockStore.mix = (fn, obj) ->
     istanbul.Store.mix fn, obj
-  mockFslookup = sinon.stub
-    keys: ->
-    get: ->
-    hasKey: ->
-    set: ->
-  mockStore.create = sinon.stub().returns mockFslookup
 
   mockAdd = sinon.spy()
   mockDispose = sinon.spy()
@@ -55,40 +49,26 @@ describe 'reporter', ->
   beforeEach ->
     m = loadFile __dirname + '/../lib/reporter.js', mocks
 
-  describe 'BasePathStore', ->
+  describe 'SourceCacheStore', ->
     options = store = null
 
     beforeEach ->
       options =
-        basePath: 'path/to/coverage/'
-      store = new m.BasePathStore options
+        sourceCache: { './foo': 'TEST_SRC_DATA' }
+      store = new m.SourceCacheStore options
 
-    describe 'toKey', ->
-      it 'should concat relative path and basePath', ->
-        expect(store.toKey './foo').to.deep.equal path.join(options.basePath, 'foo')
+    it 'should fail on call to keys', ->
+      expect(-> store.keys()).to.throw()
 
-      it 'should does not concat absolute path and basePath', ->
-        expect(store.toKey '/foo').to.deep.equal '/foo'
+    it 'should call get and check cache data', ->
+      expect(store.get('./foo')).to.equal 'TEST_SRC_DATA'
 
-    it 'should call keys and delegate to inline store', ->
-      store.keys()
-      expect(mockFslookup.keys).to.have.been.called
+    it 'should call hasKey and check cache data', ->
+      expect(store.hasKey('./foo')).to.be.true
+      expect(store.hasKey('./bar')).to.be.false
 
-    it 'should call get and delegate to inline store', ->
-      key = './path/to/js'
-      store.get(key)
-      expect(mockFslookup.get).to.have.been.calledWith path.join(options.basePath, key)
-
-    it 'should call hasKey and delegate to inline store', ->
-      key = './path/to/js'
-      store.hasKey(key)
-      expect(mockFslookup.hasKey).to.have.been.calledWith path.join(options.basePath, key)
-
-    it 'should call set and delegate to inline store', ->
-      key = './path/to/js'
-      content = 'any content'
-      store.set key, content
-      expect(mockFslookup.set).to.have.been.calledWith path.join(options.basePath, key), content
+    it 'should fail on call to set', ->
+      expect(-> store.set()).to.throw()
 
   describe 'CoverageReporter', ->
     rootConfig = emitter = reporter = null


### PR DESCRIPTION
Files with intermediate pre-processing (such as CoffeeScript) were failing on the default HTML reporter, as per issue #22. This commit adds an in-memory source cache to provide Istanbul with the exact JS code that was fed into the instrumenter (even when the original is CoffeeScript), so that full HTML detail reports can be generated on that JS.

Obviously full support for annotating CoffeeScript would be best implemented as part of Istanbul itself - but this at least fixes the exception and helps get some value of the detail report.
