### PR TITLE
Config must request to writeJsonFile otherwise will not

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -88,20 +88,6 @@ var CoverageReporter = function(rootConfig, helper, logger) {
     if (result && result.coverage) {
       collector.add(result.coverage);
     }
-
-    pendingFileWritings++;
-    helper.mkdirIfNotExists(outDir, function() {
-      var now = dateformat(new Date(), 'yyyymmdd_HHMMss');
-      var name = 'coverage-' + browser.name + '-' + now + '.json';
-      var filepath = path.join(outDir, name);
-      log.debug('Writing coverage to %s', filepath);
-      fs.writeFile(filepath, JSON.stringify(collector.getFinalCoverage()), 'utf8', function(err) {
-        if (err) {
-          log.error(err);
-        }
-        writeEnd();
-      });
-    });
   };
 
   this.onSpecComplete = function(browser, result) {
@@ -110,7 +96,7 @@ var CoverageReporter = function(rootConfig, helper, logger) {
     }
   };
 
-  this.onRunComplete = function(browsers, results) {
+  this.onRunComplete = function(browsers) {
     reporters.forEach(function(reporterConfig) {
       browsers.forEach(function(browser) {
         var collector = collectors[browser.id];

--- a/test/reporter.spec.coffee
+++ b/test/reporter.spec.coffee
@@ -122,7 +122,6 @@ describe 'reporter', ->
       browsers.add fakeOpera
       reporter.onRunStart()
       browsers.forEach (b) -> reporter.onBrowserStart b
-      mockFs.writeFile.reset()
       mockMkdir.reset()
 
     it 'has no pending file writings', ->
@@ -139,21 +138,6 @@ describe 'reporter', ->
     it 'should handle no result', ->
       reporter.onBrowserComplete fakeChrome, undefined
       expect(mockAdd).not.to.have.been.called
-
-    it 'should store coverage json', ->
-      result =
-        coverage:
-          aaa: 1
-          bbb: 2
-      reporter.onBrowserComplete fakeChrome, result
-      expect(mockAdd).to.have.been.calledWith result.coverage
-      expect(mockMkdir).to.have.been.called
-      args = mockMkdir.lastCall.args
-      expect(args[0]).to.deep.equal path.resolve('/base', rootConfig.coverageReporter.dir)
-      args[1]()
-      expect(mockFs.writeFile).to.have.been.calledWith
-      args2 = mockFs.writeFile.lastCall.args
-      # expect(args2[1]).to.deep.equal JSON.stringify(result.coverage)
 
     it 'should make reports', ->
       reporter.onRunComplete browsers


### PR DESCRIPTION
Found that karma-coverage is creating a json file every run. I don't need it and would like to avoid writing a grunt task to delete these extra files. I'd like to see it disabled by default.

With this change, if you need the json, then include this in your karma.conf
        coverageReporter: {
             writeFile: true
        }

Open to different ways to do this, just give me some feedback and I'll get it done.
