### PR TITLE
Update ibrik version to 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "SATO taichi <ryushi@gmail.com>",
   "dependencies": {
     "istanbul": "~0.1.45",
-    "ibrik":  "~0.0.4",
+    "ibrik":  "~1.0.1",
     "dateformat": "~1.0.6"
   },
   "peerDependencies": {


### PR DESCRIPTION
Fixed `make` dependency in ibrik for non-Unix environment.

Sorry for the inconvenience. I've released ibrik 1.0.1.
