### PR TITLE
Multiple reporters config does not honor `dir` option

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -116,7 +116,8 @@ var CoverageReporter = function(rootConfig, helper, logger) {
         var collector = collectors[browser.id];
         if (collector) {
           pendingFileWritings++;
-          var out = path.resolve(outDir, browser.name);
+          var reporterDir = reporterConfig.dir ? helper.normalizeWinPath(path.resolve(basePath, reporterConfig.dir)) : outDir;
+          var out = path.resolve(reporterDir, browser.name);
           helper.mkdirIfNotExists(out, function() {
             log.debug('Writing coverage to %s', out);
             var options = helper.merge({}, reporterConfig, {

--- a/test/reporter.spec.coffee
+++ b/test/reporter.spec.coffee
@@ -164,9 +164,10 @@ describe 'reporter', ->
       reporter.onRunComplete browsers
       expect(mockMkdir.callCount.should.equal browsers.length * rootConfig.coverageReporter.reporters.length)
       dir = rootConfig.coverageReporter.dir
-      expect(mockMkdir.getCall(0).args[0]).to.deep.equal path.resolve(rootConfig.basePath, dir, fakeChrome.name)
-      expect(mockMkdir.getCall(1).args[0]).to.deep.equal path.resolve(rootConfig.basePath, dir, fakeOpera.name)
-      # reporters
+      expect(mockMkdir.getCall(0).args[0]).to.deep.equal path.resolve(rootConfig.basePath, rootConfig.coverageReporter.reporters[0].dir, fakeChrome.name)
+      expect(mockMkdir.getCall(1).args[0]).to.deep.equal path.resolve(rootConfig.basePath, rootConfig.coverageReporter.reporters[0].dir, fakeOpera.name)
+      expect(mockMkdir.getCall(2).args[0]).to.deep.equal path.resolve(rootConfig.basePath, dir, fakeChrome.name)
+      expect(mockMkdir.getCall(3).args[0]).to.deep.equal path.resolve(rootConfig.basePath, dir, fakeOpera.name)
       mockMkdir.getCall(0).args[1]()
       expect(mockReportCreate).to.have.been.called
       expect(mockWriteReport).to.have.been.called


### PR DESCRIPTION
In README.md in the section for configuring [multiple reporters](https://github.com/karma-runner/karma-coverage#multiple-reporters) there is an error. Even though `dir` is specified for the HTML reporter the setting is ignored and the default value `"coverage"` is used for all reporters.

I've added tests that highlight that difference and the corresponding patch.
