### PR TITLE
Upped dependency on 'ibrik' to newer version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-coverage",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "A Karma plugin. Generate code coverage.",
   "main": "lib/index.js",
   "scripts": {
@@ -20,7 +20,7 @@
   "author": "SATO taichi <ryushi@gmail.com>",
   "dependencies": {
     "istanbul": "~0.1.45",
-    "ibrik":  "~1.0.1",
+    "ibrik":  "~1.1.1",
     "dateformat": "~1.0.6"
   },
   "peerDependencies": {


### PR DESCRIPTION
Simply changed the dependency information in package.json. The older ibrik has a hard-wired git dependency and so is causing problems for our repository where that is forbidden.
