### PR TITLE
fix: Don't use OS specific browser name in directory name. Fix #61

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea/

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -97,13 +97,14 @@ var CoverageReporter = function(rootConfig, helper, logger) {
   };
 
   this.onRunComplete = function(browsers) {
+    var browserCount = 1; // To avoid platform-specific folder names, we use an index.
     reporters.forEach(function(reporterConfig) {
       browsers.forEach(function(browser) {
         var collector = collectors[browser.id];
         if (collector) {
           pendingFileWritings++;
           var reporterOutDir = helper.isDefined(reporterConfig.dir) ? helper.normalizeWinPath(path.resolve(basePath, reporterConfig.dir)) : outDir,
-              out = path.resolve(reporterOutDir, browser.name);
+              out = path.resolve(reporterOutDir, (browserCount++).toString());
           helper.mkdirIfNotExists(out, function() {
             log.debug('Writing coverage to %s', out);
             var options = helper.merge({}, reporterConfig, {

--- a/test/reporter.spec.coffee
+++ b/test/reporter.spec.coffee
@@ -143,8 +143,8 @@ describe 'reporter', ->
       reporter.onRunComplete browsers
       expect(mockMkdir).to.have.been.calledTwice
       dir = rootConfig.coverageReporter.dir
-      expect(mockMkdir.getCall(0).args[0]).to.deep.equal path.resolve('/base', dir, fakeChrome.name)
-      expect(mockMkdir.getCall(1).args[0]).to.deep.equal path.resolve('/base', dir, fakeOpera.name)
+      expect(mockMkdir.getCall(0).args[0]).to.deep.equal path.resolve('/base', dir, '1') # Hard-coded is ok because it mirrors .getCall order
+      expect(mockMkdir.getCall(1).args[0]).to.deep.equal path.resolve('/base', dir, '2')
       mockMkdir.getCall(0).args[1]()
       expect(mockReportCreate).to.have.been.called
       expect(mockWriteReport).to.have.been.called


### PR DESCRIPTION
Notes in #61. Looking for a way to keep the folder name the same no matter what environment you're on.

If you want to use the coverage output in any kind of reliable way, in needs to be in a fixed location. This is one way to do it, but I don't love the solution :)
