### PR TITLE
fix: optional option no longer trigger an error when omitted

### DIFF
--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -4,7 +4,7 @@ var istanbul  = require('istanbul'),
 
 var createCoveragePreprocessor = function(logger, basePath, reporters, coverageReporter) {
   var log = logger.create('preprocessor.coverage');
-  var instrumenterOverrides = coverageReporter.instrumenter || {};
+  var instrumenterOverrides = (coverageReporter && coverageReporter.instrumenter) || {};
   var instrumenters = {istanbul: istanbul, ibrik: ibrik};
 
   // if coverage reporter is not used, do not preprocess the files


### PR DESCRIPTION
The `coverageReporter.instrumenter` object can be passed to the karma
configuration to override the automatic instrumenters inferring (since this
[PR](https://github.com/karma-runner/karma-coverage/pull/79)). However, when the `coverageReporter` key was omitted, a type error was
emitted.
