### PR TITLE
Cleaner Middle path overrides / Not Hacky

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -42,6 +42,7 @@ var CoverageReporter = function(rootConfig, helper, logger) {
   var config = rootConfig.coverageReporter || {};
   var basePath = rootConfig.basePath;
   var outDir = helper.normalizeWinPath(path.resolve(basePath, config.dir || 'coverage'));
+  var middlePathDir = config.middlePathDir;
   var reporters = config.reporters;
 
   if (!helper.isDefined(reporters)) {
@@ -103,7 +104,7 @@ var CoverageReporter = function(rootConfig, helper, logger) {
         if (collector) {
           pendingFileWritings++;
           var reporterOutDir = helper.isDefined(reporterConfig.dir) ? helper.normalizeWinPath(path.resolve(basePath, reporterConfig.dir)) : outDir,
-              out = path.resolve(reporterOutDir, browser.name);
+              out = path.resolve(reporterOutDir, middlePathDir || browser.name);
           helper.mkdirIfNotExists(out, function() {
             log.debug('Writing coverage to %s', out);
             var options = helper.merge({}, reporterConfig, {

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -104,7 +104,7 @@ var CoverageReporter = function(rootConfig, helper, logger) {
         if (collector) {
           pendingFileWritings++;
           var reporterOutDir = helper.isDefined(reporterConfig.dir) ? helper.normalizeWinPath(path.resolve(basePath, reporterConfig.dir)) : outDir,
-              out = path.resolve(reporterOutDir, middlePathDir || browser.name);
+              out = path.resolve(reporterOutDir, middlePathDir || reporterConfig.middlePathDir || browser.name);
           helper.mkdirIfNotExists(out, function() {
             log.debug('Writing coverage to %s', out);
             var options = helper.merge({}, reporterConfig, {


### PR DESCRIPTION
middlepath to override some browser long awful name

I did the same thing with this karma plugin as well.

https://github.com/nmccready/karma-html-reporter/blob/master/index.js#L56