### PR TITLE
feat: new `subdir` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,43 @@ If no filename is given, it will write the output to the console.
 **Description:** This will be used to output coverage reports. When
   you set a relative path, the directory is resolved against the `basePath`.
 
+#### subdir
+**Type:** String
+
+**Description**: This will be used in complement of the `coverageReporter.dir`
+option to generate the full output directory path. By default, the output
+directory is set to `./config.dir/BROWSER_NAME/`, this option allows you to
+custom the second part. You can either pass a string or a function which will be
+called with the `browser` passed as the only argument.
+
+```javascript
+coverageReporter: {
+  dir: 'coverage',
+  subdir: '.'
+  // Would output the results into: .'/coverage/'
+}
+```
+
+```javascript
+coverageReporter: {
+  dir: 'coverage',
+  subdir: 'report'
+  // Would output the results into: .'/coverage/report/'
+}
+```
+
+```javascript
+coverageReporter: {
+  dir: 'coverage',
+  subdir: function(browser) {
+    // normalization process to keep a consistent browser name accross different
+    // OS
+    return browser.toLowerCase().split(/[ /-]/)[0];
+  }
+  // Would output the results into: './coverage/firefox/'
+}
+```
+
 #### multiple reporters
 You can use multiple reporters, by providing array of options.
 

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -41,7 +41,6 @@ var CoverageReporter = function(rootConfig, helper, logger) {
   var log = logger.create('coverage');
   var config = rootConfig.coverageReporter || {};
   var basePath = rootConfig.basePath;
-  var outDir = helper.normalizeWinPath(path.resolve(basePath, config.dir || 'coverage'));
   var reporters = config.reporters;
 
   if (!helper.isDefined(reporters)) {
@@ -61,6 +60,27 @@ var CoverageReporter = function(rootConfig, helper, logger) {
       });
       fileWritingFinished();
     }
+  }
+
+  /**
+   * Generate the output directory from the `coverageReporter.dir` and
+   * `coverageReporter.subdir` options.
+   *
+   * @param {String} browserName - The browser name
+   * @param {String} dir - The given option
+   * @param {String|Function} subdir - The given option
+   *
+   * @return {String} - The output directory
+   */
+  function generateOutputDir(browserName, dir, subdir) {
+    dir = dir || 'coverage';
+    subdir = subdir || browserName;
+
+    if (typeof subdir === 'function') {
+      subdir = subdir(browserName);
+    }
+
+    return path.join(dir, subdir);
   }
 
   this.onRunStart = function(browsers) {
@@ -99,15 +119,17 @@ var CoverageReporter = function(rootConfig, helper, logger) {
   this.onRunComplete = function(browsers) {
     reporters.forEach(function(reporterConfig) {
       browsers.forEach(function(browser) {
+
         var collector = collectors[browser.id];
         if (collector) {
           pendingFileWritings++;
-          var reporterOutDir = helper.isDefined(reporterConfig.dir) ? helper.normalizeWinPath(path.resolve(basePath, reporterConfig.dir)) : outDir,
-              out = path.resolve(reporterOutDir, browser.name);
-          helper.mkdirIfNotExists(out, function() {
-            log.debug('Writing coverage to %s', out);
+
+          var outputDir = helper.normalizeWinPath(path.resolve(basePath, generateOutputDir(browser.name, config.dir, config.subdir)));
+
+          helper.mkdirIfNotExists(outputDir, function() {
+            log.debug('Writing coverage to %s', outputDir);
             var options = helper.merge({}, reporterConfig, {
-              dir : out,
+              dir : outputDir,
               sourceStore : new BasePathStore({
                 basePath : basePath
               })
@@ -121,6 +143,7 @@ var CoverageReporter = function(rootConfig, helper, logger) {
             writeEnd();
           });
         }
+
       });
     });
   };

--- a/package.json
+++ b/package.json
@@ -29,17 +29,18 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "mocks": "0.0.11",
-    "grunt": "~0.4.1",
-    "grunt-simple-mocha": "~0.4.0",
-    "grunt-contrib-jshint": "~0.6.0",
-    "karma": "~0.12.0",
-    "sinon": "~1.7.3",
     "chai": "~1.7.2",
-    "sinon-chai": "~2.4.0",
+    "grunt": "~0.4.1",
+    "grunt-auto-release": "~0.0.1",
     "grunt-bump": "~0.0.7",
+    "grunt-contrib-jshint": "~0.6.0",
     "grunt-npm": "~0.0.2",
-    "grunt-auto-release": "~0.0.1"
+    "grunt-simple-mocha": "~0.4.0",
+    "karma": "~0.12.0",
+    "lodash": "^2.4.1",
+    "mocks": "0.0.11",
+    "sinon": "~1.7.3",
+    "sinon-chai": "~2.4.0"
   },
   "contributors": [
     "Friedel Ziegelmayer <friedel.ziegelmayer@gmail.com>",


### PR DESCRIPTION
We discussed in this [issue](https://github.com/karma-runner/karma-coverage/pull/62) about the problem of not being able to choose the
whole output directory.

This commit addresses this issue and add the new `subdir` option which allows to
specify the full output directory of each coverage report.
