### PR TITLE
fix: reporters can be configured individually

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -124,7 +124,9 @@ var CoverageReporter = function(rootConfig, helper, logger) {
         if (collector) {
           pendingFileWritings++;
 
-          var outputDir = helper.normalizeWinPath(path.resolve(basePath, generateOutputDir(browser.name, config.dir, config.subdir)));
+          var outputDir = helper.normalizeWinPath(path.resolve(basePath, generateOutputDir(browser.name,
+                                                                                           reporterConfig.dir || config.dir,
+                                                                                           reporterConfig.subdir || config.subdir)));
 
           helper.mkdirIfNotExists(outputDir, function() {
             log.debug('Writing coverage to %s', outputDir);

--- a/test/reporter.spec.coffee
+++ b/test/reporter.spec.coffee
@@ -144,7 +144,6 @@ describe 'reporter', ->
 
     it 'should support a string for the subdir option', ->
       customConfig = _.merge {}, rootConfig,
-        subdir: 'test'
         coverageReporter:
           subdir: 'test'
 
@@ -164,7 +163,6 @@ describe 'reporter', ->
 
     it 'should support a function for the subdir option', ->
       customConfig = _.merge {}, rootConfig,
-        subdir: 'test'
         coverageReporter:
           subdir: (browserName) -> browserName.toLowerCase().split(/[ /-]/)[0]
 
@@ -177,6 +175,64 @@ describe 'reporter', ->
       dir = customConfig.coverageReporter.dir
       expect(mockMkdir.getCall(0).args[0]).to.deep.equal path.resolve('/base', dir, 'chrome')
       expect(mockMkdir.getCall(1).args[0]).to.deep.equal path.resolve('/base', dir, 'opera')
+      mockMkdir.getCall(0).args[1]()
+      expect(mockReportCreate).to.have.been.called
+      expect(mockWriteReport).to.have.been.called
+
+    it 'should support a specific dir and subdir per reporter', ->
+      customConfig = _.merge {}, rootConfig,
+        coverageReporter:
+          dir: 'useless'
+          subdir: 'useless'
+          reporters: [
+            {
+              dir: 'reporter1'
+              subdir: (browserName) -> browserName.toLowerCase().split(/[ /-]/)[0]
+            }
+            {
+              dir: 'reporter2'
+              subdir: (browserName) -> browserName.toUpperCase().split(/[ /-]/)[0]
+            }
+          ]
+
+      reporter = new m.CoverageReporter customConfig, mockHelper, mockLogger
+      reporter.onRunStart()
+      browsers.forEach (b) -> reporter.onBrowserStart b
+
+      reporter.onRunComplete browsers
+      expect(mockMkdir.callCount).to.equal 4
+      expect(mockMkdir.getCall(0).args[0]).to.deep.equal path.resolve('/base', 'reporter1', 'chrome')
+      expect(mockMkdir.getCall(1).args[0]).to.deep.equal path.resolve('/base', 'reporter1', 'opera')
+      expect(mockMkdir.getCall(2).args[0]).to.deep.equal path.resolve('/base', 'reporter2', 'CHROME')
+      expect(mockMkdir.getCall(3).args[0]).to.deep.equal path.resolve('/base', 'reporter2', 'OPERA')
+      mockMkdir.getCall(0).args[1]()
+      expect(mockReportCreate).to.have.been.called
+      expect(mockWriteReport).to.have.been.called
+
+    it 'should fallback to the default dir/subdir if not provided', ->
+      customConfig = _.merge {}, rootConfig,
+        coverageReporter:
+          dir: 'defaultdir'
+          subdir: 'defaultsubdir'
+          reporters: [
+            {
+              dir: 'reporter1'
+            }
+            {
+              subdir: (browserName) -> browserName.toUpperCase().split(/[ /-]/)[0]
+            }
+          ]
+
+      reporter = new m.CoverageReporter customConfig, mockHelper, mockLogger
+      reporter.onRunStart()
+      browsers.forEach (b) -> reporter.onBrowserStart b
+
+      reporter.onRunComplete browsers
+      expect(mockMkdir.callCount).to.equal 4
+      expect(mockMkdir.getCall(0).args[0]).to.deep.equal path.resolve('/base', 'reporter1', 'defaultsubdir')
+      expect(mockMkdir.getCall(1).args[0]).to.deep.equal path.resolve('/base', 'reporter1', 'defaultsubdir')
+      expect(mockMkdir.getCall(2).args[0]).to.deep.equal path.resolve('/base', 'defaultdir', 'CHROME')
+      expect(mockMkdir.getCall(3).args[0]).to.deep.equal path.resolve('/base', 'defaultdir', 'OPERA')
       mockMkdir.getCall(0).args[1]()
       expect(mockReportCreate).to.have.been.called
       expect(mockWriteReport).to.have.been.called


### PR DESCRIPTION
The `subdir` option previously introduced in karma-coverage 0.2.5 brings a
regression: it wasn't possible anymore to configure a specific output
directory/subdirectory for each reporter. This fix makes it possible again.

Fix #91
