### PR TITLE
Adds `json` reporter type to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ module.exports = function(config) {
   * `text-summary`
   * `cobertura` (xml format supported by Jenkins)
   * `teamcity` (code coverage System Messages for TeamCity)
+  * `json` (json format supported by [`grunt-istanbul-coverage`](https://github.com/daniellmb/grunt-istanbul-coverage))
 
 If you set `type` to `text` or `text-summary`, you may set the `file` option, like this.
 ```javascript


### PR DESCRIPTION
It seems that older versions of Karma (0.10.x at least) would output
`coverage-final.json` by default. Newer versions no longer do this and
require the reporter type to be specified.

See for instance the issue in [`grunt-istanbul-coverage`](https://github.com/daniellmb/grunt-istanbul-coverage/issues/14) that was caused by this.