### PR TITLE
Add merge, single and mergedDir options to coverageReporter

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -49,6 +49,8 @@ var CoverageReporter = function(rootConfig, helper, logger) {
 
   this.adapters = [];
   var collectors;
+  var mergedCollector;
+  var noSingleReport = config.merge && !config.single;
   var pendingFileWritings = 0;
   var fileWritingFinished = function() {};
 
@@ -87,18 +89,28 @@ var CoverageReporter = function(rootConfig, helper, logger) {
     collectors = Object.create(null);
 
     // TODO(vojta): remove once we don't care about Karma 0.10
-    if (browsers) {
+    if ( !noSingleReport && browsers) {
       browsers.forEach(function(browser) {
         collectors[browser.id] = new istanbul.Collector();
       });
     }
+
+    if ( config.merge ) {
+      mergedCollector = new istanbul.Collector( );
+    }
   };
 
   this.onBrowserStart = function(browser) {
-    collectors[browser.id] = new istanbul.Collector();
+    if ( !noSingleReport ) {
+      collectors[browser.id] = new istanbul.Collector();
+    }
   };
 
   this.onBrowserComplete = function(browser, result) {
+    if ( result && result.coverage && config.merge ) {
+      mergedCollector.add( result.coverage );
+    }
+
     var collector = collectors[browser.id];
 
     if (!collector) {
@@ -111,7 +123,11 @@ var CoverageReporter = function(rootConfig, helper, logger) {
   };
 
   this.onSpecComplete = function(browser, result) {
-    if (result.coverage) {
+    if ( config.merge && result.coverage ) {
+      mergedCollector.add( result.coverage );
+    }
+
+    if (!noSingleReport && result.coverage ) {
       collectors[browser.id].add(result.coverage);
     }
   };
@@ -147,6 +163,29 @@ var CoverageReporter = function(rootConfig, helper, logger) {
         }
 
       });
+
+      if ( mergedCollector ) {
+        var outputDir = helper.normalizeWinPath(path.resolve(basePath, generateOutputDir(reporterConfig.mergedDir || config.mergedDir || '',
+                                                                                         reporterConfig.dir || config.dir,
+                                                                                         reporterConfig.subdir || config.subdir)));
+
+        helper.mkdirIfNotExists(outputDir, function() {
+          log.debug('Writing coverage to %s', outputDir);
+          var options = helper.merge({}, reporterConfig, {
+            dir : outputDir,
+            sourceStore : new BasePathStore({
+              basePath : basePath
+            })
+          });
+          var reporter = istanbul.Report.create(reporterConfig.type || 'html', options);
+          try {
+            reporter.writeReport( mergedCollector , true);
+          } catch (e) {
+            log.error(e);
+          }
+          writeEnd();
+        });
+      }
     });
   };
 

--- a/test/reporter.spec.coffee
+++ b/test/reporter.spec.coffee
@@ -142,6 +142,44 @@ describe 'reporter', ->
       expect(mockReportCreate).to.have.been.called
       expect(mockWriteReport).to.have.been.called
 
+    it 'should merge reports', ->
+      customConfig = _.merge {}, rootConfig,
+        coverageReporter:
+          merge: true
+
+      reporter = new m.CoverageReporter customConfig, mockHelper, mockLogger
+      reporter.onRunStart()
+      browsers.forEach (b) -> reporter.onBrowserStart b
+
+      reporter.onRunComplete browsers
+      expect(mockMkdir).to.have.been.calledOnce
+      dir = customConfig.coverageReporter.dir
+      expect(mockMkdir.getCall(0).args[0]).to.deep.equal path.resolve('/base', dir, '' )
+      mockMkdir.getCall(0).args[1]()
+      expect(mockReportCreate).to.have.been.called
+      expect(mockWriteReport).to.have.been.called
+
+    it 'should make and merge reports', ->
+      customConfig = _.merge {}, rootConfig,
+        coverageReporter:
+          merge: true
+          single: true
+          mergedDir : 'all'
+
+      reporter = new m.CoverageReporter customConfig, mockHelper, mockLogger
+      reporter.onRunStart()
+      browsers.forEach (b) -> reporter.onBrowserStart b
+
+      reporter.onRunComplete browsers
+      expect(mockMkdir).to.have.been.calledThrice
+      dir = customConfig.coverageReporter.dir
+      expect(mockMkdir.getCall(0).args[0]).to.deep.equal path.resolve('/base', dir, fakeChrome.name )
+      expect(mockMkdir.getCall(1).args[0]).to.deep.equal path.resolve('/base', dir, fakeOpera.name )
+      expect(mockMkdir.getCall(2).args[0]).to.deep.equal path.resolve('/base', dir, 'all' )
+      mockMkdir.getCall(0).args[1]()
+      expect(mockReportCreate).to.have.been.called
+      expect(mockWriteReport).to.have.been.called
+
     it 'should support a string for the subdir option', ->
       customConfig = _.merge {}, rootConfig,
         coverageReporter:


### PR DESCRIPTION
Add mergedDir, merge and single options to converageReporter.

If merge option is set to true, the variable mergedCollector will be used instead of collectors (if single option is not set to true) and only one report will be created.
If both, single and merge, options is set to true, collectors and mergedCollector variables are used and all the reports will be created (one for each browser and one merged report).

Additionally, it's possible to specify a "merged subdir" with the mergedDir options (this works like the browser name).

Tests were added to reporter.spec that verify these features:
 - 'should merge reports' - uses the merge option and creates only one merged report.
 - 'should make and merge reports' - also uses the single and mergedDir ('all') options to create three reports (merged report is created in the '/base', dir, 'all' path).