### PR TITLE
Allow to use a custom basePath in coverage reports + minor fixes

### DIFF
--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -1,8 +1,10 @@
 var istanbul  = require('istanbul'),
     ibrik     = require('ibrik'),
-    minimatch = require('minimatch');
+    minimatch = require('minimatch'),
+    path      = require('path');
 
 var createCoveragePreprocessor = function(logger, basePath, reporters, coverageReporter) {
+  basePath = coverageReporter.reportBasePath || basePath;
   var log = logger.create('preprocessor.coverage');
   var instrumenterOverrides = (coverageReporter && coverageReporter.instrumenter) || {};
   var instrumenters = {istanbul: istanbul, ibrik: ibrik};
@@ -35,7 +37,7 @@ var createCoveragePreprocessor = function(logger, basePath, reporters, coverageR
   return function(content, file, done) {
     log.debug('Processing "%s".', file.originalPath);
 
-    var jsPath = file.originalPath.replace(basePath + '/', './');
+    var jsPath = path.relative(basePath, file.originalPath);
     var instrumenterLiteral = jsPath.match(/\.coffee$/) ? 'ibrik' : 'istanbul';
 
     for (var pattern in instrumenterOverrides) {

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -21,7 +21,7 @@ Store.mix(BasePathStore, {
     return this.delegate.keys();
   },
   toKey : function(key) {
-    if (key.indexOf('./') === 0) { return path.join(this.basePath, key); }
+    if (key.indexOf('/') !== 0) { return path.join(this.basePath, key); }
     return key;
   },
   get : function(key) {
@@ -41,6 +41,7 @@ var CoverageReporter = function(rootConfig, helper, logger) {
   var log = logger.create('coverage');
   var config = rootConfig.coverageReporter || {};
   var basePath = rootConfig.basePath;
+  var reportBasePath = config.reportBasePath || rootConfig.basePath;
   var reporters = config.reporters;
 
   if (!helper.isDefined(reporters)) {
@@ -133,7 +134,7 @@ var CoverageReporter = function(rootConfig, helper, logger) {
             var options = helper.merge({}, reporterConfig, {
               dir : outputDir,
               sourceStore : new BasePathStore({
-                basePath : basePath
+                basePath : reportBasePath
               })
             });
             var reporter = istanbul.Report.create(reporterConfig.type || 'html', options);

--- a/test/preprocessor.spec.coffee
+++ b/test/preprocessor.spec.coffee
@@ -54,7 +54,7 @@ describe 'preprocessor', ->
         something: ->
 
       vm.runInNewContext preprocessedCode, sandbox
-      expect(sandbox.__coverage__).to.have.ownProperty './file.js'
+      expect(sandbox.__coverage__).to.have.ownProperty 'file.js'
       done()
 
   it 'should preprocess the coffee code', (done) ->
@@ -68,7 +68,7 @@ describe 'preprocessor', ->
 
       vm.runInNewContext preprocessedCode, sandbox
       expect(file.path).to.equal '/base/path/file.js'
-      expect(sandbox.__coverage__).to.have.ownProperty './file.coffee'
+      expect(sandbox.__coverage__).to.have.ownProperty 'file.coffee'
       done()
 
   it 'should not preprocess the coffee code', (done) ->
@@ -84,7 +84,7 @@ describe 'preprocessor', ->
 
       vm.runInNewContext preprocessedCode, sandbox
       expect(file.path).to.equal '/base/path/file.coffee'
-      expect(sandbox.__coverage__).to.have.ownProperty './file.coffee'
+      expect(sandbox.__coverage__).to.have.ownProperty 'file.coffee'
       done()
 
   it 'should fail if invalid instrumenter provided', (done) ->


### PR DESCRIPTION
 * add an optionnal configuration key "coverageReporter.reportBasePath" to specify the base path used in reports. Defaults to karma's basePath. Use case: maven + SonarQube integration:
   * js sources are symlinked in a temporary directory and built there to avoid source tree pollution
   * paths in lcov reports are relative to this temporary directory
   * SonarQube expects paths in report to be relative to ${project.basedir}
   * when setting coverageReporter.reportBasePath to ${project.basedir}, SonarQube is able to find files and to follow symlinks up to the original sources.

 * preprocessor: use path.resolve instead of string replace. Should be safer and cope well with gory symlinks. Update tests accordingly
 * reporter: relative paths do not necessarily start with ./. Check for leading / instead.