### PR TITLE
Upgrade ibrik to 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "SATO taichi <ryushi@gmail.com>",
   "dependencies": {
     "istanbul": "~0.3.0",
-    "ibrik": "~1.1.1",
+    "ibrik": "2.0.0",
     "dateformat": "~1.0.6",
     "minimatch": "~0.3.0"
   },


### PR DESCRIPTION
Cause karma-coverage to use the 2.x Ibrik, which relies on coffee-script instead of redux. This allows users to get code coverage for CS projects w/o needing to work around bugs in coffee-script-redux (esp. `super` and `try` w/o catch).
