### PR TITLE
fix: when using browserify dont create source code caching

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -133,10 +133,10 @@ var CoverageReporter = function(rootConfig, helper, logger) {
           var outputDir = helper.normalizeWinPath(path.resolve(basePath, generateOutputDir(browser.name,
                                                                                            reporterConfig.dir || config.dir,
                                                                                            reporterConfig.subdir || config.subdir)));
-
+          var _ = helper._;
           var options = helper.merge({}, reporterConfig, {
             dir : outputDir,
-            sourceStore : new SourceCacheStore({
+            sourceStore : _.isEmpty(sourceCache) ? null : new SourceCacheStore({
               sourceCache: sourceCache
             })
           });

--- a/test/reporter.spec.coffee
+++ b/test/reporter.spec.coffee
@@ -34,6 +34,7 @@ describe 'reporter', ->
   mockReportCreate = sinon.stub().returns writeReport: mockWriteReport
   mockMkdir = sinon.spy()
   mockHelper =
+    _: helper._
     isDefined: (v) -> helper.isDefined v
     merge: (v...) -> helper.merge v...
     mkdirIfNotExists: mockMkdir


### PR DESCRIPTION
Simple check when using browserify for coverage and there is nothing in sourceCache.

Example of [karma.conf.js](https://github.com/piecyk/image-shop/blob/IS-4/test/karma.conf.js) with browserify and karma-coverage.