### PR TITLE
allow optionnal absolutePath flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ module.exports = function(config) {
     coverageReporter: {
       type : 'html',
       dir : 'coverage/'
+      absolutePath: true
     }
   });
 };
@@ -142,6 +143,12 @@ module.exports = function(config) {
 
 **Description:** This will be used to output coverage reports. When
   you set a relative path, the directory is resolved against the `basePath`.
+  
+#### absolutePath
+**Type:** String
+
+**Description:** This will be used to output coverage reports. When
+  you set to true, the directory is not resolved against the `basePath` but with absolute path.
 
 #### subdir
 **Type:** String

--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -5,6 +5,7 @@ var istanbul  = require('istanbul'),
 
 var createCoveragePreprocessor = function(logger, basePath, reporters, coverageReporter) {
   var log = logger.create('preprocessor.coverage');
+  var absolutePath = (coverageReporter.absolutePath === true);
   var instrumenterOverrides = (coverageReporter && coverageReporter.instrumenter) || {};
   var instrumenters = {istanbul: istanbul, ibrik: ibrik};
   var sourceCache = globalSourceCache.getByBasePath(basePath);
@@ -37,7 +38,7 @@ var createCoveragePreprocessor = function(logger, basePath, reporters, coverageR
   return function(content, file, done) {
     log.debug('Processing "%s".', file.originalPath);
 
-    var jsPath = file.originalPath.replace(basePath + '/', './');
+    var jsPath = absolutePath ? file.originalPath : file.originalPath.replace(basePath + '/', './');
     var instrumenterLiteral = jsPath.match(/\.coffee$/) ? 'ibrik' : 'istanbul';
 
     for (var pattern in instrumenterOverrides) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-coverage",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "A Karma plugin. Generate code coverage.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Coveralls.io and other coverage tools need absolute path in lcov.

Regards