### PR TITLE
feat: add support for including all sources in coverage data

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,20 @@ coverageReporter: {
 }
 ```
 
+#### includeAllSources
+**Type:** Boolean
+
+You can opt to include all sources files, as indicated by the coverage preprocessor, in your code coverage data, even if there are no tests covering them. (Default `false`)
+
+```javascript
+coverageReporter: {
+  type : 'text',
+  dir : 'coverage/',
+  file : 'coverage.txt',
+  includeAllSources: true
+}
+```
+
 #### multiple reporters
 You can use multiple reporters, by providing array of options.
 

--- a/lib/coverageMap.js
+++ b/lib/coverageMap.js
@@ -1,0 +1,19 @@
+var coverageMap = {};
+
+function addCoverage(coverageObj){
+	coverageMap[coverageObj.path] = coverageObj;
+}
+
+function getCoverageMap(){
+  return coverageMap;
+}
+
+function resetCoverage(){
+	coverageMap = {};
+}
+
+module.exports = {
+    add: addCoverage,
+    get: getCoverageMap,
+    reset: resetCoverage
+  };

--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -1,13 +1,15 @@
 var istanbul  = require('istanbul'),
     minimatch = require('minimatch'),
     globalSourceCache = require('./sourceCache'),
-    extend = require('util')._extend;
+    extend = require('util')._extend,
+    coverageMap = require('./coverageMap');
 
 var createCoveragePreprocessor = function(logger, basePath, reporters, coverageReporter) {
   var log = logger.create('preprocessor.coverage');
   var instrumenterOverrides = (coverageReporter && coverageReporter.instrumenter) || {};
   var instrumenters = extend({istanbul: istanbul}, (coverageReporter && coverageReporter.instrumenters));
   var sourceCache = globalSourceCache.getByBasePath(basePath);
+  var includeAllSources = coverageReporter && coverageReporter.includeAllSources === true;
   var instrumentersOptions = Object.keys(instrumenters).reduce(function getInstumenterOptions(memo, instrumenterName){
     memo[instrumenterName] = (coverageReporter && coverageReporter.instrumenterOptions && coverageReporter.instrumenterOptions[instrumenterName]) || {};
     return memo;
@@ -61,6 +63,17 @@ var createCoveragePreprocessor = function(logger, basePath, reporters, coverageR
 
       // remember the actual immediate instrumented JS for given original path
       sourceCache[jsPath] = content;
+
+      if (includeAllSources) {
+        var coverageObjRegex = /\{.*"path".*"fnMap".*"statementMap".*"branchMap".*\}/g;
+        var coverageObjMatch = coverageObjRegex.exec(instrumentedCode);
+
+        if (coverageObjMatch !== null) {
+			var coverageObj = JSON.parse(coverageObjMatch[0]);
+			
+			coverageMap.add(coverageObj);
+        }
+      }
 
       done(instrumentedCode);
     });

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -4,6 +4,7 @@ var util = require('util');
 var istanbul = require('istanbul');
 var dateformat = require('dateformat');
 var globalSourceCache = require('./sourceCache');
+var coverageMap = require('./coverageMap');
 
 
 var Store = istanbul.Store;
@@ -39,6 +40,7 @@ var CoverageReporter = function(rootConfig, helper, logger) {
   var basePath = rootConfig.basePath;
   var reporters = config.reporters;
   var sourceCache = globalSourceCache.getByBasePath(basePath);
+  var includeAllSources = config.includeAllSources === true;
 
   if (!helper.isDefined(reporters)) {
     reporters = [config];
@@ -91,14 +93,15 @@ var CoverageReporter = function(rootConfig, helper, logger) {
 
     // TODO(vojta): remove once we don't care about Karma 0.10
     if (browsers) {
-      browsers.forEach(function(browser) {
-        collectors[browser.id] = new istanbul.Collector();
-      });
+      browsers.forEach(this.onBrowserStart.bind(this));
     }
   };
 
   this.onBrowserStart = function(browser) {
     collectors[browser.id] = new istanbul.Collector();
+    if(includeAllSources){
+      collectors[browser.id].add(coverageMap.get());
+    }
   };
 
   this.onBrowserComplete = function(browser, result) {

--- a/test/coverageMap.spec.coffee
+++ b/test/coverageMap.spec.coffee
@@ -1,0 +1,28 @@
+coverageMap = require '../lib/coverageMap'
+coverageObj = { path: './path.js', otherThings: 'that are in instrumented code' }
+
+describe 'coverageMap', ->
+  it 'should add coverageMap and get them', ->
+    coverageMap.add(coverageObj)
+
+    expect(coverageMap.get()['./path.js']).to.equal coverageObj
+
+  it 'should be able to be reset', ->
+    coverageMap.reset()
+
+    expect(coverageMap.get()['./path.js']).to.not.exist
+
+    coverageMap.add(coverageObj)
+
+    expect(coverageMap.get()['./path.js']).to.equal coverageObj
+
+    coverageMap.reset()
+
+    expect(coverageMap.get()['./path.js']).to.not.exist
+
+  it 'should be able to have multiple coverageMap', ->
+    coverageMap.reset()
+    coverageMap.add(coverageObj)
+    coverageMap.add({ path: './anotherFile.js', moarKeys: [1, 2, 3] })
+
+    expect(Object.keys(coverageMap.get()).length).to.equal 2

--- a/test/preprocessor.spec.coffee
+++ b/test/preprocessor.spec.coffee
@@ -1,6 +1,8 @@
 vm = require 'vm'
 util = require 'util'
 
+coverageMap = require '../lib/coverageMap'
+
 describe 'preprocessor', ->
   createPreprocessor = require '../lib/preprocessor'
 
@@ -124,3 +126,33 @@ describe 'preprocessor', ->
           '**/*.coffee': 'madeup'
     expect(work).to.throw()
     done()
+
+  it 'should add coverageMap when including all sources', (done) ->
+    process = createPreprocessor mockLogger, '/base/path', ['coverage'], { includeAllSources: true }
+    file = new File '/base/path/file.js'
+
+    coverageMap.reset()
+
+    process ORIGINAL_CODE, file, (preprocessedCode) ->
+      expect(coverageMap.get()['./file.js']).to.exist
+      done()
+
+  it 'should not add coverageMap when not including all sources', (done) ->
+    process = createPreprocessor mockLogger, '/base/path', ['coverage'], { includeAllSources: false }
+    file = new File '/base/path/file.js'
+
+    coverageMap.reset()
+
+    process ORIGINAL_CODE, file, (preprocessedCode) ->
+      expect(coverageMap.get()['./file.js']).to.not.exist
+      done()
+
+  it 'should not add coverageMap in the default state', (done) ->
+    process = createPreprocessor mockLogger, '/base/path', ['coverage'], {}
+    file = new File '/base/path/file.js'
+
+    coverageMap.reset()
+
+    process ORIGINAL_CODE, file, (preprocessedCode) ->
+      expect(coverageMap.get()['./file.js']).to.not.exist
+      done()


### PR DESCRIPTION
I would love the ability to include all sources in my coverage reports, otherwise it gives me a false sense of confidence about my coverage. In my testing, this does the trick by adding stubs for all instrumented files to the Collector.

Happy to take any feedback to make this better.

Should resolve https://github.com/karma-runner/karma-coverage/issues/125