### PR TITLE
fix: reporter allow using a externally provided source cachere for reporters

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,20 @@ coverageReporter: {
 }
 ```
 
+#### sourceStore
+**Type:** istanbul.Store
+
+You can opt to specify a source store allowing for external coverage collectors access to the instrumented code.
+
+```javascript
+coverageReporter: {
+  type : 'text',
+  dir : 'coverage/',
+  file : 'coverage.txt',
+  sourceStore : require('istanbul').Store.create('fslookup')
+}
+```
+
 #### multiple reporters
 You can use multiple reporters, by providing array of options.
 

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -138,11 +138,12 @@ var CoverageReporter = function(rootConfig, helper, logger) {
                                                                                            reporterConfig.dir || config.dir,
                                                                                            reporterConfig.subdir || config.subdir)));
           var _ = helper._;
-          var options = helper.merge({}, config, reporterConfig, {
-            dir : outputDir,
+          var options = helper.merge({
             sourceStore : _.isEmpty(sourceCache) ? null : new SourceCacheStore({
               sourceCache: sourceCache
             })
+          }, config, reporterConfig, {
+            dir : outputDir
           });
           var reporter = istanbul.Report.create(reporterConfig.type || 'html', options);
 


### PR DESCRIPTION
change `coverageReporter` options to allow for specifying `sourceStore`, this
is an instance of `istanbul.Store` to look up source files. This allows using
external coverage collectors like `browserify-istanbul` for instrumenting code.

references #16, #123, #124