### PR TITLE
fix: watermarks are not handled correctly

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -42,6 +42,10 @@ var CoverageReporter = function(rootConfig, helper, logger) {
   var sourceCache = globalSourceCache.getByBasePath(basePath);
   var includeAllSources = config.includeAllSources === true;
 
+  if (config.watermarks) {
+    config.watermarks = helper.merge({}, istanbul.config.defaultConfig().reporting.watermarks, config.watermarks);
+  }
+
   if (!helper.isDefined(reporters)) {
     reporters = [config];
   }
@@ -134,7 +138,7 @@ var CoverageReporter = function(rootConfig, helper, logger) {
                                                                                            reporterConfig.dir || config.dir,
                                                                                            reporterConfig.subdir || config.subdir)));
           var _ = helper._;
-          var options = helper.merge({}, reporterConfig, {
+          var options = helper.merge({}, config, reporterConfig, {
             dir : outputDir,
             sourceStore : _.isEmpty(sourceCache) ? null : new SourceCacheStore({
               sourceCache: sourceCache

--- a/test/reporter.spec.coffee
+++ b/test/reporter.spec.coffee
@@ -42,6 +42,11 @@ describe 'reporter', ->
   mockCoverageMap =
     add: sinon.spy()
     get: sinon.spy()
+  mockDefaultWatermarks =
+    statements: [50, 80]
+    branches: [50, 80]
+    functions: [50, 80]
+    lines: [50, 80]
 
   mocks =
     fs: mockFs
@@ -49,6 +54,7 @@ describe 'reporter', ->
       Store: mockStore
       Collector: mockCollector
       Report: create: mockReportCreate
+      config: defaultConfig: sinon.stub().returns(reporting: watermarks: mockDefaultWatermarks)
     dateformat: require 'dateformat'
     './coverageMap': mockCoverageMap
 
@@ -294,3 +300,58 @@ describe 'reporter', ->
       browsers.forEach (b) -> reporter.onBrowserStart b
 
       expect(mockCoverageMap.get).not.to.have.been.called
+
+    it 'should pass watermarks to istanbul', ->
+      watermarks =
+        statements: [10, 20]
+        branches: [30, 40]
+        functions: [50, 60]
+        lines: [70, 80]
+
+      customConfig = _.merge {}, rootConfig,
+        coverageReporter:
+          reporters: [
+            {
+              dir: 'reporter1'
+            }
+          ]
+          watermarks: watermarks
+
+      mockReportCreate.reset()
+
+      reporter = new m.CoverageReporter customConfig, mockHelper, mockLogger
+      reporter.onRunStart()
+      browsers.forEach (b) -> reporter.onBrowserStart b
+      reporter.onRunComplete browsers
+
+      expect(mockReportCreate).to.have.been.called
+      options = mockReportCreate.getCall(0)
+      expect(options.args[1].watermarks).to.deep.equal(watermarks)
+
+    it 'should merge with istanbul default watermarks', ->
+      watermarks =
+        statements: [10, 20]
+        lines: [70, 80]
+
+      customConfig = _.merge {}, rootConfig,
+        coverageReporter:
+          reporters: [
+            {
+              dir: 'reporter1'
+            }
+          ]
+          watermarks: watermarks
+
+      mockReportCreate.reset()
+
+      reporter = new m.CoverageReporter customConfig, mockHelper, mockLogger
+      reporter.onRunStart()
+      browsers.forEach (b) -> reporter.onBrowserStart b
+      reporter.onRunComplete browsers
+
+      expect(mockReportCreate).to.have.been.called
+      options = mockReportCreate.getCall(0)
+      expect(options.args[1].watermarks.statements).to.deep.equal(watermarks.statements)
+      expect(options.args[1].watermarks.branches).to.deep.equal(mockDefaultWatermarks.branches)
+      expect(options.args[1].watermarks.functions).to.deep.equal(mockDefaultWatermarks.functions)
+      expect(options.args[1].watermarks.lines).to.deep.equal(watermarks.lines)


### PR DESCRIPTION
- Merges the coverageReporter config with the options passed to each reporter.
- Merges in specified watermarks with the Istanbul defaults so that only some types need to be specified.

Closes #143, #144 