### PR TITLE
feat(preprocessor): Add sourcemap support

### DIFF
--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -8,6 +8,8 @@
 
 var istanbul = require('istanbul')
 var minimatch = require('minimatch')
+var SourceMapConsumer = require('source-map').SourceMapConsumer
+var SourceMapGenerator = require('source-map').SourceMapGenerator
 var globalSourceCache = require('./source-cache')
 var extend = require('util')._extend
 var coverageMap = require('./coverage-map')
@@ -85,12 +87,37 @@ function createCoveragePreprocessor (logger, helper, basePath, reporters, covera
     })
 
     var InstrumenterConstructor = instrumenters[instrumenterLiteral].Instrumenter
-    var constructOptions = instrumentersOptions[instrumenterLiteral]
-    var instrumenter = new InstrumenterConstructor(constructOptions || {})
+    var constructOptions = instrumentersOptions[instrumenterLiteral] || {}
+    var codeGenerationOptions = null
 
+    if (file.sourceMap) {
+      log.debug('Enabling source map generation for "%s".', file.originalPath)
+      codeGenerationOptions = extend({
+        format: {
+          compact: !constructOptions.noCompact
+        },
+        sourceMap: file.sourceMap.file,
+        sourceMapWithCode: true,
+        file: file.path
+      }, constructOptions.codeGenerationOptions || {})
+    }
+
+    var options = extend({}, constructOptions)
+    options = extend(options, {codeGenerationOptions: codeGenerationOptions})
+
+    var instrumenter = new InstrumenterConstructor(options)
     instrumenter.instrument(content, jsPath, function (err, instrumentedCode) {
       if (err) {
         log.error('%s\n  at %s', err.message, file.originalPath)
+      }
+
+      if (file.sourceMap && instrumenter.lastSourceMap()) {
+        log.debug('Adding source map to instrumented file for "%s".', file.originalPath)
+        var generator = SourceMapGenerator.fromSourceMap(new SourceMapConsumer(instrumenter.lastSourceMap().toString()))
+        generator.applySourceMap(new SourceMapConsumer(file.sourceMap))
+        file.sourceMap = JSON.parse(generator.toString())
+        instrumentedCode += '\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,'
+        instrumentedCode += new Buffer(JSON.stringify(file.sourceMap)).toString('base64') + '\n'
       }
 
       // remember the actual immediate instrumented JS for given original path

--- a/package.json
+++ b/package.json
@@ -19,9 +19,10 @@
   ],
   "author": "SATO taichi <ryushi@gmail.com>",
   "dependencies": {
-    "istanbul": "^0.3.0",
+    "istanbul": "^0.3.15",
     "dateformat": "^1.0.6",
-    "minimatch": "^2.0.8"
+    "minimatch": "^2.0.8",
+    "source-map": "^0.4.2"
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
Pending https://github.com/gotwarlost/istanbul/pull/349, which is needed to fix istanbul sourcemap outputs to have the correct offset.

Adds sourcemap support to the preprocessor. If the file being
processed has a sourcemap property, it is merged with the output
from the coverage instrumentation. This enables better debugging
on instrumented code.

Closes #109