### PR TITLE
docs(readme): correct link to istanbul

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,4 +284,4 @@ For more information on Karma see the [homepage].
 
 
 [homepage]: http://karma-runner.github.com
-[Istanbul]: https://github.com/yahoo/istanbul
+[Istanbul]: https://github.com/gotwarlost/istanbul


### PR DESCRIPTION
The URL is not the original Istanbul repository. I fixed the link.