### PR TITLE
fix(preprocessor): use absolute paths

### DIFF
--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -76,7 +76,6 @@ function createCoveragePreprocessor (logger, helper, basePath, reporters, covera
   return function (content, file, done) {
     log.debug('Processing "%s".', file.originalPath)
 
-    var jsPath = file.originalPath.replace(basePath + '/', './')
     // default instrumenters
     var instrumenterLiteral = 'istanbul'
 
@@ -106,7 +105,7 @@ function createCoveragePreprocessor (logger, helper, basePath, reporters, covera
     options = extend(options, {codeGenerationOptions: codeGenerationOptions})
 
     var instrumenter = new InstrumenterConstructor(options)
-    instrumenter.instrument(content, jsPath, function (err, instrumentedCode) {
+    instrumenter.instrument(content, file.originalPath, function (err, instrumentedCode) {
       if (err) {
         log.error('%s\n  at %s', err.message, file.originalPath)
       }
@@ -121,7 +120,7 @@ function createCoveragePreprocessor (logger, helper, basePath, reporters, covera
       }
 
       // remember the actual immediate instrumented JS for given original path
-      sourceCache[jsPath] = content
+      sourceCache[file.originalPath] = content
 
       if (includeAllSources) {
         var coverageObjMatch = coverageObjRegex.exec(instrumentedCode)

--- a/test/preprocessor.spec.coffee
+++ b/test/preprocessor.spec.coffee
@@ -58,7 +58,7 @@ describe 'preprocessor', ->
         something: ->
 
       vm.runInNewContext preprocessedCode, sandbox
-      expect(sandbox.__coverage__).to.have.ownProperty './file.js'
+      expect(sandbox.__coverage__).to.have.ownProperty '/base/path/file.js'
       done()
 
   it 'should preprocess the fake code', (done) ->
@@ -118,7 +118,7 @@ describe 'preprocessor', ->
 
       vm.runInNewContext preprocessedCode, sandbox
       expect(file.path).to.equal '/base/path/file.coffee'
-      expect(sandbox.__coverage__).to.have.ownProperty './file.coffee'
+      expect(sandbox.__coverage__).to.have.ownProperty '/base/path/file.coffee'
       done()
 
   it 'should fail if invalid instrumenter provided', (done) ->
@@ -136,7 +136,7 @@ describe 'preprocessor', ->
     coverageMap.reset()
 
     process ORIGINAL_CODE, file, (preprocessedCode) ->
-      expect(coverageMap.get()['./file.js']).to.exist
+      expect(coverageMap.get()['/base/path/file.js']).to.exist
       done()
 
   it 'should not add coverageMap when not including all sources', (done) ->


### PR DESCRIPTION
According to the [spec](https://github.com/gotwarlost/istanbul/blob/master/coverage.json.md), the absolute file path should be used in the coverage report. Currently karma-coverage substitutes this with a path relative to `baseDir`. This causes problems when trying to combine coverage with other reports not generated by karma-coverage.

Fixing this would help with #1.