### PR TITLE
fix(preprocessor) Reset coverageObjRegex before each use

### DIFF
--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -123,6 +123,9 @@ function createCoveragePreprocessor (logger, helper, basePath, reporters, covera
       sourceCache[file.originalPath] = content
 
       if (includeAllSources) {
+        // reset stateful regex
+        coverageObjRegex.lastIndex = 0
+
         var coverageObjMatch = coverageObjRegex.exec(instrumentedCode)
 
         if (coverageObjMatch !== null) {


### PR DESCRIPTION
When using the `includeAllSources` flag, every other non-tested file is included.  This appears to be because the `coverageObjRegex` is global and shared.  Resetting the regex allows files to match correctly when `coverageObjRegex.exec()` is called.

Likely to help partially resolve https://github.com/karma-runner/karma-coverage/issues/166, if not completely.