### PR TITLE
Paths in windows use backslash (fixes #178)

### DIFF
--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -76,6 +76,7 @@ function createCoveragePreprocessor (logger, helper, basePath, reporters, covera
   return function (content, file, done) {
     log.debug('Processing "%s".', file.originalPath)
 
+    var jsPath = require.resolve(file.originalPath)
     // default instrumenters
     var instrumenterLiteral = 'istanbul'
 
@@ -105,7 +106,7 @@ function createCoveragePreprocessor (logger, helper, basePath, reporters, covera
     options = extend(options, {codeGenerationOptions: codeGenerationOptions})
 
     var instrumenter = new InstrumenterConstructor(options)
-    instrumenter.instrument(content, file.originalPath, function (err, instrumentedCode) {
+    instrumenter.instrument(content, jsPath, function (err, instrumentedCode) {
       if (err) {
         log.error('%s\n  at %s', err.message, file.originalPath)
       }
@@ -120,7 +121,7 @@ function createCoveragePreprocessor (logger, helper, basePath, reporters, covera
       }
 
       // remember the actual immediate instrumented JS for given original path
-      sourceCache[file.originalPath] = content
+      sourceCache[jsPath] = content
 
       if (includeAllSources) {
         var coverageObjMatch = coverageObjRegex.exec(instrumentedCode)


### PR DESCRIPTION
This ensures paths are using backslashes in windows, consistent with outputs from istanbul.