### PR TITLE
fix(preprocessor): Call done with error message instead of populating instrumentedCode

### DIFF
--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -112,39 +112,40 @@ function createCoveragePreprocessor (logger, helper, basePath, reporters, covera
     instrumenter.instrument(content, jsPath, function (err, instrumentedCode) {
       if (err) {
         log.error('%s\n  at %s', err.message, file.originalPath)
-      }
-
-      if (file.sourceMap && instrumenter.lastSourceMap()) {
-        log.debug('Adding source map to instrumented file for "%s".', file.originalPath)
-        var generator = SourceMapGenerator.fromSourceMap(new SourceMapConsumer(instrumenter.lastSourceMap().toString()))
-        generator.applySourceMap(new SourceMapConsumer(file.sourceMap))
-        file.sourceMap = JSON.parse(generator.toString())
-        instrumentedCode += '\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,'
-        instrumentedCode += new Buffer(JSON.stringify(file.sourceMap)).toString('base64') + '\n'
-      }
-
-      // remember the actual immediate instrumented JS for given original path
-      sourceCache[jsPath] = content
-
-      if (includeAllSources) {
-        // reset stateful regex
-        coverageObjRegex.lastIndex = 0
-
-        var coverageObjMatch = coverageObjRegex.exec(instrumentedCode)
-
-        if (coverageObjMatch !== null) {
-          var coverageObj = JSON.parse(coverageObjMatch[0])
-
-          coverageMap.add(coverageObj)
+        done(err.message)
+      } else {
+        if (file.sourceMap && instrumenter.lastSourceMap()) {
+          log.debug('Adding source map to instrumented file for "%s".', file.originalPath)
+          var generator = SourceMapGenerator.fromSourceMap(new SourceMapConsumer(instrumenter.lastSourceMap().toString()))
+          generator.applySourceMap(new SourceMapConsumer(file.sourceMap))
+          file.sourceMap = JSON.parse(generator.toString())
+          instrumentedCode += '\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,'
+          instrumentedCode += new Buffer(JSON.stringify(file.sourceMap)).toString('base64') + '\n'
         }
-      }
 
-      // RequireJS expects JavaScript files to end with `.js`
-      if (useJSExtensionForCoffeeScript && instrumenterLiteral === 'ibrik') {
-        file.path = file.path.replace(/\.coffee$/, '.js')
-      }
+        // remember the actual immediate instrumented JS for given original path
+        sourceCache[jsPath] = content
 
-      done(instrumentedCode)
+        if (includeAllSources) {
+          // reset stateful regex
+          coverageObjRegex.lastIndex = 0
+
+          var coverageObjMatch = coverageObjRegex.exec(instrumentedCode)
+
+          if (coverageObjMatch !== null) {
+            var coverageObj = JSON.parse(coverageObjMatch[0])
+
+            coverageMap.add(coverageObj)
+          }
+        }
+
+        // RequireJS expects JavaScript files to end with `.js`
+        if (useJSExtensionForCoffeeScript && instrumenterLiteral === 'ibrik') {
+          file.path = file.path.replace(/\.coffee$/, '.js')
+        }
+
+        done(instrumentedCode)
+      }
     })
   }
 }


### PR DESCRIPTION
This fixes an issue related to Karma dying when is watching files via `singleRun: false`. Please read issue at https://github.com/karma-runner/karma/issues/1783

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/karma-runner/karma-coverage/204)
<!-- Reviewable:end -->
