### PR TITLE
feat(in-memory-reporter) Added "in-memory"  reporter

### DIFF
--- a/lib/in-memory-report.js
+++ b/lib/in-memory-report.js
@@ -1,0 +1,13 @@
+
+function InMemoryReport (opt) {
+  this.browser = opt.browser
+  this.emitter = opt.emitter
+}
+
+InMemoryReport.prototype.writeReport = function (collector, sync) {
+  this.emitter.emit('coverage_complete', this.browser, collector.getFinalCoverage())
+}
+
+InMemoryReport.TYPE = 'in-memory'
+
+module.exports = InMemoryReport

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,9 @@
 // Main entry point for the karma-coverage module.
 // Exposes the preprocessor and reporter plugins.
 
+// Registering one additional (karma specific) reporter: in-memory
+require('istanbul').Report.register(require('./in-memory-report'))
+
 module.exports = {
   'preprocessor:coverage': ['factory', require('./preprocessor')],
   'reporter:coverage': ['type', require('./reporter')]

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -27,7 +27,7 @@ function isAbsolute (file) {
 }
 
 // TODO(vojta): inject only what required (config.basePath, config.coverageReporter)
-var CoverageReporter = function (rootConfig, helper, logger) {
+var CoverageReporter = function (rootConfig, helper, logger, emitter) {
   var _ = helper._
   var log = logger.create('coverage')
 
@@ -270,15 +270,17 @@ var CoverageReporter = function (rootConfig, helper, logger) {
         var options = helper.merge({
           sourceStore: sourceStore
         }, config, reporterConfig, {
-          dir: outputDir
+          dir: outputDir,
+          browser: browser,
+          emitter: emitter
         })
         var reporter = istanbul.Report.create(reporterConfig.type || 'html', options)
 
-        // If reporting to console, skip directory creation
-        var isConsole = reporterConfig.type && reporterConfig.type.match(/^(text|text-summary)$/)
+         // If reporting to console or in-memory skip directory creation
+        var toDisk = !reporterConfig.type || !reporterConfig.type.match(/^(text|text-summary|in-memory)$/)
         var hasNoFile = _.isUndefined(reporterConfig.file)
 
-        if (isConsole && hasNoFile) {
+        if (!toDisk && hasNoFile) {
           writeReport(reporter, collector)
           return
         }
@@ -303,7 +305,7 @@ var CoverageReporter = function (rootConfig, helper, logger) {
   }
 }
 
-CoverageReporter.$inject = ['config', 'helper', 'logger']
+CoverageReporter.$inject = ['config', 'helper', 'logger', 'emitter']
 
 // PUBLISH
 module.exports = CoverageReporter

--- a/test/in-memory-report.spec.coffee
+++ b/test/in-memory-report.spec.coffee
@@ -1,0 +1,19 @@
+InMemoryReport = require '../lib/in-memory-report'
+
+describe 'InMemoryReport', ->  
+
+  emitter = 
+    emit: sinon.stub()
+  browser = { name: 'firefox' }
+  result = { coverage: 'result' }
+  collector =
+    getFinalCoverage: sinon.stub().returns result
+  
+  it 'should raise an "coverage_complete" event.', ->
+    sut = new InMemoryReport { browser: browser, emitter: emitter}
+    sut.writeReport collector
+    expect(collector.getFinalCoverage).to.have.been.called
+    expect(emitter.emit).to.have.been.calledWith('coverage_complete', browser, result)
+    
+  it 'should be of type "in-memory"', ->
+    expect(InMemoryReport.TYPE).to.be.equal('in-memory')

--- a/test/index.spec.coffee
+++ b/test/index.spec.coffee
@@ -1,0 +1,7 @@
+index = require '../lib/index'
+InMemoryReport = require '../lib/in-memory-report'
+istanbul = require 'istanbul'
+
+describe 'Index', ->  
+  it 'should register "InMemoryReport" to istanbul', ->
+    expect(istanbul.Report.create('in-memory', {})).to.be.an.instanceof(InMemoryReport)

--- a/test/reporter.spec.coffee
+++ b/test/reporter.spec.coffee
@@ -108,7 +108,7 @@ describe 'reporter', ->
         basePath: '/base'
         coverageReporter: dir: 'path/to/coverage/'
       emitter = new events.EventEmitter
-      reporter = new m.CoverageReporter rootConfig, mockHelper, mockLogger
+      reporter = new m.CoverageReporter rootConfig, mockHelper, mockLogger, emitter
       browsers = new Collection emitter
       # fake user agent only for testing
       # cf. helper.browserFullNameToShort
@@ -144,6 +144,10 @@ describe 'reporter', ->
       mockMkdir.getCall(0).args[1]()
       expect(mockReportCreate).to.have.been.called
       expect(mockWriteReport).to.have.been.called
+      createArgs = mockReportCreate.getCall(0).args
+      expect(createArgs[0]).to.be.equal 'html'
+      expect(createArgs[1].browser).to.be.equal fakeChrome
+      expect(createArgs[1].emitter).to.be.equal emitter
 
     it 'should support a string for the subdir option', ->
       customConfig = _.merge {}, rootConfig,


### PR DESCRIPTION
Added the 'in-memory' reporter which raises an event rather than writing the report to disk. I register the report to Istanbul so it uses its factory method design pattern to create the reporter.
resolve issue #215 