### PR TITLE
Adding event callbacks for "writeReport" and "onExit" functions

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -59,6 +59,12 @@ var CoverageReporter = function (rootConfig, helper, logger, emitter) {
 
   function writeReport (reporter, collector) {
     try {
+      if (typeof config._onWriteReport === 'function') {
+        var newCollector = config._onWriteReport(collector)
+        if (typeof newCollector === 'object') {
+          collector = newCollector
+        }
+      }
       reporter.writeReport(collector, true)
     } catch (e) {
       log.error(e)
@@ -298,9 +304,13 @@ var CoverageReporter = function (rootConfig, helper, logger, emitter) {
 
   this.onExit = function (done) {
     if (pendingFileWritings) {
-      fileWritingFinished = done
+      fileWritingFinished = (
+        typeof config._onExit === 'function'
+        ? (function (done) { return function () { config._onExit(done) } }(done))
+        : done
+      )
     } else {
-      done()
+      (typeof config._onExit === 'function' ? config._onExit(done) : done())
     }
   }
 }


### PR DESCRIPTION
Hello, I've been [working on providing a more sustainable coverage solution for a project called "jspm-karma"](https://github.com/Workiva/karma-jspm/pull/147), and if okay with you guys, I would like to use the reporter files for karma-coverage as is. All I really need are callbacks into the `writeReport` and `onExit` functions. Let me know if this is doable, thanks in advance.
