### PR TITLE
docs(config): Add none as possible value for type

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,6 +16,7 @@
   * `teamcity` (code coverage System Messages for TeamCity)
   * `json` (json format supported by [`grunt-istanbul-coverage`](https://github.com/daniellmb/grunt-istanbul-coverage))
   * `in-memory` (supported since v0.5.4)
+  * `none` (Does nothing. Use to specify that no reporting is needed)
 
 ### `dir`
 


### PR DESCRIPTION
Add `none` as possible value for reporter type.

Istanbul supports a report implementation that does nothing, called `none`. This report can be used when no reporting is needed.