### PR TITLE
feat(reporter): Allows aggregation by browser name instead of browser id

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -47,7 +47,7 @@ var CoverageReporter = function (rootConfig, helper, logger, emitter) {
 
   // allow configuration "{coverageReporter: { browserId: 'name' }}"
   // to aggregate coverage across browsers
-  var identifier = config.browserId || 'id';
+  var identifier = config.browserId || 'id'
 
   if (config.watermarks) {
     config.watermarks = helper.merge({}, istanbul.config.defaultConfig().reporting.watermarks, config.watermarks)
@@ -246,20 +246,18 @@ var CoverageReporter = function (rootConfig, helper, logger, emitter) {
     collectors[browser[identifier]].add(result.coverage)
   }
 
-
   this.onRunComplete = function (browsers, results) {
     var checkedCoverage = {}
 
     reporters.forEach(function (reporterConfig) {
-
-      var seen = {};
+      var seen = {}
 
       browsers.forEach(function (browser) {
         // ensure we don't report on a collector twice
         if (seen[browser[identifier]]) {
           return
         }
-        seen[browser[identifier]] = 1;
+        seen[browser[identifier]] = 1
 
         var collector = collectors[browser[identifier]]
 

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -45,6 +45,10 @@ var CoverageReporter = function (rootConfig, helper, logger, emitter) {
   var sourceCache = globalSourceCache.get(basePath)
   var includeAllSources = config.includeAllSources === true
 
+  // allow configuration "{coverageReporter: { browserId: 'name' }}"
+  // to aggregate coverage across browsers
+  var identifier = config.browserId || 'id';
+
   if (config.watermarks) {
     config.watermarks = helper.merge({}, istanbul.config.defaultConfig().reporting.watermarks, config.watermarks)
   }
@@ -218,15 +222,17 @@ var CoverageReporter = function (rootConfig, helper, logger, emitter) {
   }
 
   this.onBrowserStart = function (browser) {
-    collectors[browser.id] = new istanbul.Collector()
+    if (!collectors[browser[identifier]]) {
+      collectors[browser[identifier]] = new istanbul.Collector()
 
-    if (!includeAllSources) return
+      if (!includeAllSources) return
 
-    collectors[browser.id].add(coverageMap.get())
+      collectors[browser[identifier]].add(coverageMap.get())
+    }
   }
 
   this.onBrowserComplete = function (browser, result) {
-    var collector = collectors[browser.id]
+    var collector = collectors[browser[identifier]]
 
     if (!collector) return
     if (!result || !result.coverage) return
@@ -237,23 +243,33 @@ var CoverageReporter = function (rootConfig, helper, logger, emitter) {
   this.onSpecComplete = function (browser, result) {
     if (!result.coverage) return
 
-    collectors[browser.id].add(result.coverage)
+    collectors[browser[identifier]].add(result.coverage)
   }
+
 
   this.onRunComplete = function (browsers, results) {
     var checkedCoverage = {}
 
     reporters.forEach(function (reporterConfig) {
+
+      var seen = {};
+
       browsers.forEach(function (browser) {
-        var collector = collectors[browser.id]
+        // ensure we don't report on a collector twice
+        if (seen[browser[identifier]]) {
+          return
+        }
+        seen[browser[identifier]] = 1;
+
+        var collector = collectors[browser[identifier]]
 
         if (!collector) {
           return
         }
 
         // If config.check is defined, check coverage levels for each browser
-        if (config.hasOwnProperty('check') && !checkedCoverage[browser.id]) {
-          checkedCoverage[browser.id] = true
+        if (config.hasOwnProperty('check') && !checkedCoverage[browser[identifier]]) {
+          checkedCoverage[browser[identifier]] = true
           var coverageFailed = checkCoverage(browser, collector)
           if (coverageFailed) {
             if (results) {

--- a/test/reporter.spec.coffee
+++ b/test/reporter.spec.coffee
@@ -453,3 +453,36 @@ describe 'reporter', ->
       expect(spy1).to.not.have.been.called
 
       expect(results.exitCode).to.equal 0
+
+    it 'should add two collectors when aggregating by browser id (default) when using two browsers', ->
+      customConfig = _.merge {}, rootConfig,
+        coverageReporter:
+          dir: 'defaultdir'
+
+      reporter = new m.CoverageReporter customConfig, mockHelper, mockLogger
+      reporter.onRunStart()
+      browsers = new Collection emitter
+      browsers.add new Browser 'aaa', 'Windows NT 6.1 Chrome/16.0.912.75', browsers, emitter
+      browsers.add new Browser 'bbb', 'Windows NT 6.1 Chrome/16.0.912.75', browsers, emitter
+
+      browsers.forEach (b) -> reporter.onBrowserStart b
+      reporter.onRunComplete browsers
+
+      expect(mockMkdir.callCount).to.equal 2
+
+    it 'should only add one collector when aggregating by browser name despite two ids', ->
+      customConfig = _.merge {}, rootConfig,
+        coverageReporter:
+          browserId: 'name'
+          dir: 'defaultdir'
+
+      reporter = new m.CoverageReporter customConfig, mockHelper, mockLogger
+      reporter.onRunStart()
+      browsers = new Collection emitter
+      browsers.add new Browser 'aaa', 'Windows NT 6.1 Chrome/16.0.912.75', browsers, emitter
+      browsers.add new Browser 'bbb', 'Windows NT 6.1 Chrome/16.0.912.75', browsers, emitter
+
+      browsers.forEach (b) -> reporter.onBrowserStart b
+      reporter.onRunComplete browsers
+
+      expect(mockMkdir.callCount).to.equal 1


### PR DESCRIPTION
This feature lets coverage be aggregated by a specified browser attribute rather than browser.id when you pass in 'browserId' in the configuration:

```javascript
{
  coverageReporter: {
    browserId: 'name' // defaults to 'id'
  }
}
```

This will be used in the "karma-sharding" plugin to roll up coverage reporting after specs are divided across a set of browsers.

Right now the sharding plugin overrides the karma-coverage reporter but it would be more ideal if the coverage plugin supported this sort of aggregation via configuration.
