### PR TITLE
Update Source Map Handling

### DIFF
--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -145,18 +145,18 @@ function createCoveragePreprocessor (logger, basePath, reporters = [], coverageR
         log.error('%s\n  at %s', err.message, file.originalPath)
         done(err.message)
       } else {
-        // Use the incoming source map, or the one generated from the instrumenter (if configured to generate one)
-        const sourceMap = file.sourceMap || instrumenter.lastSourceMap()
-
-        if (sourceMap) {
-          log.debug('Adding source map to instrumented file for "%s".', file.originalPath)
-          instrumentedCode += '\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,'
-          instrumentedCode += Buffer.from(JSON.stringify(sourceMap)).toString('base64') + '\n'
+        // Register the incoming sourceMap for transformation during reporting (if it exists)
+        if (file.sourceMap) {
+          sourceMapStore.registerMap(jsPath, file.sourceMap)
         }
 
-        if (file.sourceMap) {
-          // Register the sourceMap for transformation during reporting
-          sourceMapStore.registerMap(jsPath, file.sourceMap)
+        // Add merged source map (if it merged correctly)
+        const lastSourceMap = instrumenter.lastSourceMap()
+        if (lastSourceMap) {
+          log.debug('Adding source map to instrumented file for "%s".', file.originalPath)
+          file.sourceMap = lastSourceMap
+          instrumentedCode += '\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,'
+          instrumentedCode += Buffer.from(JSON.stringify(lastSourceMap)).toString('base64') + '\n'
         }
 
         if (includeAllSources) {
@@ -185,7 +185,7 @@ function createCoveragePreprocessor (logger, basePath, reporters = [], coverageR
 
         done(instrumentedCode)
       }
-    })
+    }, file.sourceMap)
   }
 }
 

--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -9,7 +9,6 @@
 const { createInstrumenter } = require('istanbul-lib-instrument')
 const minimatch = require('minimatch')
 const path = require('path')
-const { SourceMapConsumer, SourceMapGenerator } = require('source-map')
 const globalSourceMapStore = require('./source-map-store')
 const globalCoverageMap = require('./coverage-map')
 
@@ -146,17 +145,19 @@ function createCoveragePreprocessor (logger, basePath, reporters = [], coverageR
         log.error('%s\n  at %s', err.message, file.originalPath)
         done(err.message)
       } else {
-        if (file.sourceMap && instrumenter.lastSourceMap()) {
+        // Use the incoming source map, or the one generated from the instrumenter (if configured to generate one)
+        const sourceMap = file.sourceMap || instrumenter.lastSourceMap()
+
+        if (sourceMap) {
           log.debug('Adding source map to instrumented file for "%s".', file.originalPath)
-          const generator = SourceMapGenerator.fromSourceMap(new SourceMapConsumer(instrumenter.lastSourceMap().toString()))
-          generator.applySourceMap(new SourceMapConsumer(file.sourceMap))
-          file.sourceMap = JSON.parse(generator.toString())
           instrumentedCode += '\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,'
-          instrumentedCode += Buffer.from(JSON.stringify(file.sourceMap)).toString('base64') + '\n'
+          instrumentedCode += Buffer.from(JSON.stringify(sourceMap)).toString('base64') + '\n'
         }
 
-        // Register the sourceMap for transformation during reporting
-        sourceMapStore.registerMap(jsPath, file.sourceMap)
+        if (file.sourceMap) {
+          // Register the sourceMap for transformation during reporting
+          sourceMapStore.registerMap(jsPath, file.sourceMap)
+        }
 
         if (includeAllSources) {
           let coverageObj

--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
     "istanbul-lib-report": "^2.0.8",
     "istanbul-lib-source-maps": "^3.0.6",
     "istanbul-reports": "^2.2.4",
-    "minimatch": "^3.0.0",
-    "source-map": "^0.5.1"
+    "minimatch": "^3.0.0"
   },
   "license": "MIT",
   "devDependencies": {

--- a/test/preprocessor.spec.coffee
+++ b/test/preprocessor.spec.coffee
@@ -65,6 +65,8 @@ describe 'preprocessor', ->
     fakeInstanbulLikeInstrumenter::instrument = (_a, _b, callback) ->
       callback()
       return
+    fakeInstanbulLikeInstrumenter::lastSourceMap = ->
+      return
     process = createPreprocessor mockLogger, '/base/path', ['coverage', 'progress'],
       instrumenters:
        fakeInstanbulLike :
@@ -89,7 +91,8 @@ describe 'preprocessor', ->
     fakeInstanbulLikeInstrumenter::instrument = (_a, _b, callback) ->
       callback()
       return
-
+    fakeInstanbulLikeInstrumenter::lastSourceMap = ->
+      return
     process = createPreprocessor mockLogger, '/base/path', ['coverage', 'progress'],
       instrumenters:
         fakeInstanbulLike:
@@ -163,6 +166,8 @@ describe 'preprocessor', ->
     ibrikInstrumenter  = ->
     ibrikInstrumenter::instrument = (_a, _b, callback) ->
       callback()
+      return
+    ibrikInstrumenter::lastSourceMap = ->
       return
 
     process = createPreprocessor mockLogger, '/base/path', ['coverage', 'progress'],


### PR DESCRIPTION
## Changes

#### Update how source maps are handled
Instead of combining source maps manually, this is handled automatically by `istanbul-lib-instrument` when passing the input source map in as an argument in the `instrument` call.

#### Remove source-map dependency
With the removal of combining source maps, the source-map package is not longer needed.

#### Fix test mocks
The preprocessor test mocks have been updated to include the necessary mocked functions. The updated mocks don't change what is being tested.

--- 

I've created a playground to test karma-coverage [here](https://github.com/pr1sm/karma-coverage-playground/). The [master ](https://github.com/pr1sm/karma-coverage-playground/tree/346f42bfd71fef3b7f1cc84d1ff26d58ec247ed8) branch (at the time of creating this PR) is using my patch and the generated reports are correct for the few languages I tested (available [here](https://pr1sm.github.io/karma-coverage-playground/)).

The playground has really simple code/tests, but if anyone wants to test it on a bigger codebase, I'd appreciate it!

fixes #393 