### PR TITLE
fix: race condition between the Karma shutdown and coverage writing

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -290,15 +290,20 @@ var CoverageReporter = function (rootConfig, helper, logger, emitter) {
   }
 
   this.onExit = async function (done) {
-    const results = await promiseComplete
-    if (results && results.exitCode === 1) {
-      done(results.exitCode)
-      return
-    }
-    if (typeof config._onExit === 'function') {
-      config._onExit(done)
-    } else {
-      done()
+    try {
+      const results = await promiseComplete
+      if (results && results.exitCode === 1) {
+        done(results.exitCode)
+        return
+      }
+      if (typeof config._onExit === 'function') {
+        config._onExit(done)
+      } else {
+        done()
+      }
+    } catch (e) {
+      log.error('Unexpected error while generating coverage report.\n', e)
+      done(1)
     }
   }
 }

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -11,6 +11,7 @@
 // ------------
 
 var path = require('path')
+const { promisify } = require('util')
 var istanbulLibCoverage = require('istanbul-lib-coverage')
 var istanbulLibReport = require('istanbul-lib-report')
 var minimatch = require('minimatch')
@@ -264,10 +265,12 @@ var CoverageReporter = function (rootConfig, helper, logger, emitter) {
       return
     }
 
-    helper.mkdirIfNotExists(outputPath, function () {
-      log.debug('Writing coverage to %s', outputPath)
-      report.execute(context)
-    })
+    const mkdirIfNotExists = promisify(helper.mkdirIfNotExists)
+    await mkdirIfNotExists(outputPath)
+
+    log.debug('Writing coverage to %s', outputPath)
+    report.execute(context)
+
     return results
   }
 

--- a/test/reporter.spec.js
+++ b/test/reporter.spec.js
@@ -27,7 +27,10 @@ describe('reporter', () => {
   const mockHelper = {
     isDefined: (v) => helper.isDefined(v),
     merge: (...arg) => helper.merge(...arg),
-    mkdirIfNotExists: mkdirIfNotExistsStub,
+    mkdirIfNotExists: (dir, done) => {
+      mkdirIfNotExistsStub(dir, done)
+      setTimeout(done, 0)
+    },
     normalizeWinPath: (path) => helper.normalizeWinPath(path)
   }
 
@@ -166,7 +169,6 @@ describe('reporter', () => {
       const dir = rootConfig.coverageReporter.dir
       expect(mkdirIfNotExistsStub.getCall(0).args[0]).to.deep.equal(resolve('/base', dir, fakeChrome.name))
       expect(mkdirIfNotExistsStub.getCall(1).args[0]).to.deep.equal(resolve('/base', dir, fakeOpera.name))
-      mkdirIfNotExistsStub.getCall(0).args[1]()
       expect(reportCreateStub).to.have.been.called
       expect(mockPackageSummary.execute).to.have.been.called
       const createArgs = reportCreateStub.getCall(0).args
@@ -192,7 +194,6 @@ describe('reporter', () => {
       const subdir = customConfig.coverageReporter.subdir
       expect(mkdirIfNotExistsStub.getCall(0).args[0]).to.deep.equal(resolve('/base', dir, subdir))
       expect(mkdirIfNotExistsStub.getCall(1).args[0]).to.deep.equal(resolve('/base', dir, subdir))
-      mkdirIfNotExistsStub.getCall(0).args[1]()
       expect(reportCreateStub).to.have.been.called
       expect(mockPackageSummary.execute).to.have.been.called
     })
@@ -213,7 +214,6 @@ describe('reporter', () => {
       const dir = customConfig.coverageReporter.dir
       expect(mkdirIfNotExistsStub.getCall(0).args[0]).to.deep.equal(resolve('/base', dir, 'chrome'))
       expect(mkdirIfNotExistsStub.getCall(1).args[0]).to.deep.equal(resolve('/base', dir, 'opera'))
-      mkdirIfNotExistsStub.getCall(0).args[1]()
       expect(reportCreateStub).to.have.been.called
       expect(mockPackageSummary.execute).to.have.been.called
     })
@@ -246,7 +246,6 @@ describe('reporter', () => {
       expect(mkdirIfNotExistsStub.getCall(1).args[0]).to.deep.equal(resolve('/base', 'reporter1', 'opera'))
       expect(mkdirIfNotExistsStub.getCall(2).args[0]).to.deep.equal(resolve('/base', 'reporter2', 'CHROME'))
       expect(mkdirIfNotExistsStub.getCall(3).args[0]).to.deep.equal(resolve('/base', 'reporter2', 'OPERA'))
-      mkdirIfNotExistsStub.getCall(0).args[1]()
       expect(reportCreateStub).to.have.been.called
       expect(mockPackageSummary.execute).to.have.been.called
     })
@@ -277,7 +276,6 @@ describe('reporter', () => {
       expect(mkdirIfNotExistsStub.getCall(1).args[0]).to.deep.equal(resolve('/base', 'reporter1', 'defaultsubdir'))
       expect(mkdirIfNotExistsStub.getCall(2).args[0]).to.deep.equal(resolve('/base', 'defaultdir', 'CHROME'))
       expect(mkdirIfNotExistsStub.getCall(3).args[0]).to.deep.equal(resolve('/base', 'defaultdir', 'OPERA'))
-      mkdirIfNotExistsStub.getCall(0).args[1]()
       expect(reportCreateStub).to.have.been.called
       expect(mockPackageSummary.execute).to.have.been.called
     })


### PR DESCRIPTION
The creation of parent directories is asynchronous process, which was not properly awaited, which resulted in the coverage reports not being written to the disk sometimes as Karma process has exited before the reporter completed the writing of the coverage report.

Also update the test case to use async implementation of the corresponding stub to prevent regressions in the future. ~~It seems that manually calling `done` parameter in several tests was an attempt to solve the same race condition in the unit tests. They are not needed anymore.~~ Nah, probably they are just leftovers of the old reporter implementation.

Fixes #434